### PR TITLE
issue/9

### DIFF
--- a/RushTI.py
+++ b/RushTI.py
@@ -1,11 +1,11 @@
 import asyncio
 import configparser
 import datetime
+import itertools
 import logging
 import os
 import shlex
 import sys
-import itertools
 from base64 import b64decode
 from concurrent.futures import ThreadPoolExecutor
 
@@ -20,14 +20,31 @@ def set_current_directory():
     return directory
 
 
-APPNAME = "RushTI"
+APP_NAME = "RushTI"
 CURRENT_DIRECTORY = set_current_directory()
-LOGFILE = os.path.join(CURRENT_DIRECTORY, APPNAME + ".log")
+LOGFILE = os.path.join(CURRENT_DIRECTORY, APP_NAME + ".log")
 CONFIG = os.path.join(CURRENT_DIRECTORY, "config.ini")
+
+
+MSG_RUSHTI_STARTS = "{app_name} starts. Parameters: {parameters}."
+MSG_RUSHTI_TOO_FEW_ARGUMENTS = "{app_name} needs to be executed with two arguments."
+MSG_RUSHTI_ARGUMENT1_INVALID = "Argument 1 (path to file) invalid. File needs to exist."
+MSG_RUSHTI_ARGUMENT2_INVALID = "Argument 2 (max workers) invalid. Argument needs to be an integer number."
+MSG_PROCESS_EXECUTE = "Executing process: {process_name} with parameters: {parameters} on instance: {instance_name}"
+MSG_PROCESS_SUCCESS = "Execution successful: Process {process} with parameters: {parameters} on instance: " \
+                      "{instance}. Elapsed time: {time}"
+MSG_PROCESS_FAIL_INSTANCE_NOT_AVAILABLE = "Process {process_name} not executed on {instance_name}. " \
+                                          "{instance_name} not accessible."
+MSG_PROCESS_FAIL_WITH_ERROR_FILE = "Execution failed. Process: {process} with parameters: {parameters} and status: " \
+                                   "{status}, on instance: {instance}. Elapsed time : {time}. Error file: {error_file}"
+MSG_PROCESS_FAIL_UNEXPECTED = "Execution failed. Process: {process} with parameters: {parameters}. " \
+                              "Elapsed time: {time}. Error: {error}."
+MSG_RUSHTI_ENDS = "{app_name} ends. {fails} fails out of {executions} executions. Elapsed time: {time}"
+
 
 logging.basicConfig(
     filename=LOGFILE,
-    format='%(asctime)s - ' + APPNAME + ' - %(levelname)s - %(message)s',
+    format='%(asctime)s - ' + APP_NAME + ' - %(levelname)s - %(message)s',
     level=logging.INFO)
 
 
@@ -48,7 +65,7 @@ def setup_tm1_services():
         if tm1_server_name != config.default_section:
             try:
                 params["password"] = decrypt_password(params["password"])
-                tm1_services[tm1_server_name] = TM1Service(**params, session_context=APPNAME)
+                tm1_services[tm1_server_name] = TM1Service(**params, session_context=APP_NAME)
             # Instance not running, Firewall or wrong connection parameters
             except Exception as e:
                 logging.error("TM1 instance {} not accessible. Error: {}".format(tm1_server_name, str(e)))
@@ -92,37 +109,54 @@ def execute_line(line, tm1_services):
     :return: 
     """
     if len(line.strip()) == 0:
-        return
+        return True
     instance_name, process_name, parameters = extract_info_from_line(line)
     if instance_name not in tm1_services:
-        msg = "Process {process_name} not executed on {instance_name}. {instance_name} not accessible.".format(
+        msg = MSG_PROCESS_FAIL_INSTANCE_NOT_AVAILABLE.format(
             process_name=process_name,
             instance_name=instance_name)
         logging.error(msg)
-        return
+        return False
     tm1 = tm1_services[instance_name]
+
     # Execute it
-    msg = "Executing process: {process_name} with Parameters: {parameters} on instance: {instance_name}".format(
+    msg = MSG_PROCESS_EXECUTE.format(
         process_name=process_name,
         parameters=parameters,
         instance_name=instance_name)
     logging.info(msg)
+    start_time = datetime.datetime.now()
     try:
-        response = tm1.processes.execute(process_name=process_name, **parameters)
-        msg_raw = "Execution Successful: {process_name} with Parameters: {parameters} on instance: {instance_name}. " \
-                  "Elapsed time: {elapsed_time}"
-        msg = msg_raw.format(
-            process_name=process_name,
-            parameters=parameters,
-            instance_name=instance_name,
-            elapsed_time=response.elapsed)
-        logging.info(msg)
+        success, status, error_log_file = tm1.processes.execute_with_return(process_name=process_name, **parameters)
+        elapsed_time = datetime.datetime.now() - start_time
+        if success:
+            msg = MSG_PROCESS_SUCCESS
+            msg = msg.format(
+                process=process_name,
+                parameters=parameters,
+                instance=instance_name,
+                time=elapsed_time)
+            logging.info(msg)
+            return True
+        else:
+            msg = MSG_PROCESS_FAIL_WITH_ERROR_FILE.format(
+                process=process_name,
+                parameters=parameters,
+                status=status,
+                instance=instance_name,
+                time=elapsed_time,
+                error_file=error_log_file)
+            logging.error(msg)
+            return False
     except Exception as e:
-        msg = "Execution Failed. Process: {process}, Parameters: {parameters}, Error: {error}".format(
+        elapsed_time = datetime.datetime.now() - start_time
+        msg = MSG_PROCESS_FAIL_UNEXPECTED.format(
             process=process_name,
             parameters=parameters,
-            error=str(e))
+            error=str(e),
+            time=elapsed_time)
         logging.error(msg)
+        return False
 
 
 async def work_through_tasks(path, max_workers, tm1_services):
@@ -136,18 +170,19 @@ async def work_through_tasks(path, max_workers, tm1_services):
     with open(path) as file:
         lines = file.readlines()
     loop = asyncio.get_event_loop()
-    
-    """ Split lines into the blocks separated by 'wait' line """
-    line_sets = [list(y) for x, y in itertools.groupby(lines, lambda z: z.lower().strip() == 'wait') if not x]
 
+    # split lines into the blocks separated by 'wait' line
+    line_sets = [list(y) for x, y in itertools.groupby(lines, lambda z: z.lower().strip() == 'wait') if not x]
+    # True or False for every execution
+    outcomes = []
     for line_set in line_sets:
         with ThreadPoolExecutor(max_workers=int(max_workers)) as executor:
             futures = [loop.run_in_executor(executor, execute_line, line, tm1_services)
                        for line
                        in line_set]
             for future in futures:
-                await future
-
+                outcomes.append(await future)
+    return outcomes
 
 
 def logout(tm1_services):
@@ -168,41 +203,63 @@ def translate_cmd_arguments(*args):
     """
     # too few arguments
     if len(args) < 3:
-        msg = "{app_name} needs to be executed with two arguments.".format(app_name=APPNAME)
+        msg = MSG_RUSHTI_TOO_FEW_ARGUMENTS.format(app_name=APP_NAME)
         logging.error(msg)
-        raise ValueError(msg)
+        sys.exit(msg)
     # txt file doesnt exist
     if not os.path.isfile(args[1]):
-        msg = "Argument 1 (path to file) invalid. File needs to exist."
+        msg = MSG_RUSHTI_ARGUMENT1_INVALID
         logging.error(msg)
-        raise ValueError(msg)
+        sys.exit(msg)
     # max_workers is not a number
     if not args[2].isdigit():
-        msg = "Argument 2 (max workers) invalid. Needs to be number."
+        msg = MSG_RUSHTI_ARGUMENT2_INVALID
         logging.error(msg)
-        raise ValueError(msg)
+        sys.exit(msg)
     return args[1], args[2]
 
 
-# recieves two arguments: 1) path-to-txt-file, 2) max-workers
+def exit_rushti(executions, successes, elapsed_time):
+    """ Exit RushTI with exit code 0 or 1 depending on the TI execution outcomes
+
+    :param executions: Number of executions
+    :param successes: Number of executions that succeeded
+    :param elapsed_time:
+    :return:
+    """
+    fails = executions - successes
+    message = MSG_RUSHTI_ENDS.format(
+        app_name=APP_NAME,
+        fails=fails,
+        executions=executions,
+        time=str(elapsed_time))
+    if fails > 0:
+        logging.error(message)
+        sys.exit(message)
+    else:
+        logging.info(message)
+        sys.exit(0)
+
+
+# receives two arguments: 1) path-to-txt-file, 2) max-workers
 if __name__ == "__main__":
-    logging.info("{app_name} starts. Parameters: {parameters}.".format(
-        app_name=APPNAME,
+    logging.info(MSG_RUSHTI_STARTS.format(
+        app_name=APP_NAME,
         parameters=sys.argv))
     # start timer
     start = datetime.datetime.now()
     # read commandline arguments
-    path_to_file, max_workers = translate_cmd_arguments(*sys.argv)
+    path_to_file, maximum_workers = translate_cmd_arguments(*sys.argv)
     # setup connections
-    tm1_services = setup_tm1_services()
+    tm1_service_by_instance = setup_tm1_services()
     # execution
-    loop = asyncio.get_event_loop()
+    event_loop = asyncio.get_event_loop()
     try:
-        loop.run_until_complete(work_through_tasks(path_to_file, max_workers, tm1_services))
+        results = event_loop.run_until_complete(
+            work_through_tasks(path_to_file, maximum_workers, tm1_service_by_instance))
     finally:
-        logout(tm1_services)
-        loop.close()
+        logout(tm1_service_by_instance)
+        event_loop.close()
     # timing
-    end = datetime.datetime.now()
-    duration = end - start
-    logging.info(("{app_name} ends. Duration: " + str(duration)).format(app_name=APPNAME))
+    duration = datetime.datetime.now() - start
+    exit_rushti(executions=len(results), successes=sum(results), elapsed_time=duration)


### PR DESCRIPTION
- Exit script with return_code 0 or 1, depending on whether all processes suceeded or not. Fixes #9
- Use of `execute_process_with_return` function instead of `execute_process` function. Requires TM1 >= 11.3 IF 1
- Enhance logging and messaging. Make all messages consistent