### PR TITLE
Refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,14 +60,14 @@ Clone or download the RushTI Repository
 
   Example of Tasks_type_optimized.txt:
   ```
-  id="1" predecessors="" require_predecessor_succeed="" instance="tm1srv01" process="load.actuals" pMonth=Jan
-  id="2" predecessors="1" require_predecessor_succeed="1" instance="tm1srv02" process="load.actuals" pMonth=Feb
-  id="3" predecessors="1" require_predecessor_succeed="1" instance="tm1srv01" process="load.actuals" pMonth=Mar
-  id="4" predecessors="1" require_predecessor_succeed="0" instance="tm1srv02" process="load.actuals" pMonth=Apr
-  id="5" predecessors="2,3" require_predecessor_succeed="0" instance="tm1srv01" process="load.actuals" pMonth=May
-  id="6" predecessors="4,5" require_predecessor_succeed="1" instance="tm1srv02" process="load.actuals" pMonth=Jun
-  id="7" predecessors="4" require_predecessor_succeed="0" instance="tm1srv01" process="load.actuals" pMonth=Jul
-  id="8" predecessors="6" require_predecessor_succeed="0" instance="tm1srv02" process="load.actuals" pMonth=Aug
+  id="1" predecessors="" require_predecessor_success="" instance="tm1srv01" process="load.actuals" pMonth=Jan
+  id="2" predecessors="1" require_predecessor_success="1" instance="tm1srv02" process="load.actuals" pMonth=Feb
+  id="3" predecessors="1" require_predecessor_success="1" instance="tm1srv01" process="load.actuals" pMonth=Mar
+  id="4" predecessors="1" require_predecessor_success="0" instance="tm1srv02" process="load.actuals" pMonth=Apr
+  id="5" predecessors="2,3" require_predecessor_success="0" instance="tm1srv01" process="load.actuals" pMonth=May
+  id="6" predecessors="4,5" require_predecessor_success="1" instance="tm1srv02" process="load.actuals" pMonth=Jun
+  id="7" predecessors="4" require_predecessor_success="0" instance="tm1srv01" process="load.actuals" pMonth=Jul
+  id="8" predecessors="6" require_predecessor_success="0" instance="tm1srv02" process="load.actuals" pMonth=Aug
   ```
 
 ## Running the tests

--- a/Tasks_type_optimized.txt
+++ b/Tasks_type_optimized.txt
@@ -1,8 +1,8 @@
-id="1" predecessors="" instance="tm1srv01" process="}bedrock.server.wait" pWaitSec=1
-id="2" predecessors="1" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
-id="3" predecessors="1" instance="tm1srv01" process="}bedrock.server.wait" pWaitSec=3
-id="4" predecessors="1" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=4
-id="5" predecessors="2,3" instance="tm1srv01" process="}bedrock.server.wait" pWaitSec=5
-id="6" predecessors="4,5" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=6
-id="7" predecessors="4" instance="tm1srv01" process="}bedrock.server.wait" pWaitSec=7
-id="8" predecessors="6" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=8
+id="1" predecessors="" require_predecessor_success="1" instance="tm1srv01" process="}bedrock.server.wait" pWaitSec=1
+id="2" predecessors="1" require_predecessor_success="1" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
+id="3" predecessors="1" require_predecessor_success="1" instance="tm1srv01" process="}bedrock.server.wait" pWaitSec=3
+id="4" predecessors="1" require_predecessor_success="1" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=4
+id="5" predecessors="2,3" require_predecessor_success="1" instance="tm1srv01" process="}bedrock.server.wait" pWaitSec=5
+id="6" predecessors="4,5" require_predecessor_success="1" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=6
+id="7" predecessors="4" require_predecessor_success="1" instance="tm1srv01" process="}bedrock.server.wait" pWaitSec=7
+id="8" predecessors="6" require_predecessor_success="1" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=8

--- a/tests/resources/tasks_opt_case1.txt
+++ b/tests/resources/tasks_opt_case1.txt
@@ -1,9 +1,9 @@
-id="1" predecessors="" instance="tm1srv01" process="}bedrock.server.wait" pWaitSec=1
-id="2" predecessors="1" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
-id="3" predecessors="2" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
-id="4" predecessors="3" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
-id="5" predecessors="4" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
-id="6" predecessors="5" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
-id="7" predecessors="6" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
-id="8" predecessors="7" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
-id="9" predecessors="8" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
+id="1" predecessors="" require_predecessor_success="1" instance="tm1srv01" process="}bedrock.server.wait" pWaitSec=1
+id="2" predecessors="1" require_predecessor_success="1" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
+id="3" predecessors="2" require_predecessor_success="1" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
+id="4" predecessors="3" require_predecessor_success="1" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
+id="5" predecessors="4" require_predecessor_success="1" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
+id="6" predecessors="5" require_predecessor_success="1" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
+id="7" predecessors="6" require_predecessor_success="1" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
+id="8" predecessors="7" require_predecessor_success="1" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
+id="9" predecessors="8" require_predecessor_success="1" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2

--- a/tests/resources/tasks_opt_case2.txt
+++ b/tests/resources/tasks_opt_case2.txt
@@ -1,17 +1,17 @@
-id="1" predecessors="" instance="tm1srv01" process="}bedrock.server.wait" pWaitSec=1
-id="2" predecessors="1" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
-id="3" predecessors="1" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
-id="4" predecessors="1" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
-id="5" predecessors="1" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
-id="6" predecessors="2" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
-id="7" predecessors="3" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
-id="8" predecessors="3" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
-id="9" predecessors="5" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
-id="10" predecessors="6" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
-id="11" predecessors="7" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
-id="12" predecessors="8" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
-id="13" predecessors="9" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
-id="14" predecessors="10" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
-id="15" predecessors="11" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
-id="16" predecessors="12" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
-id="17" predecessors="13" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
+id="1" predecessors="" require_predecessor_success="1" instance="tm1srv01" process="}bedrock.server.wait" pWaitSec=1
+id="2" predecessors="1" require_predecessor_success="1" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
+id="3" predecessors="1" require_predecessor_success="1" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
+id="4" predecessors="1" require_predecessor_success="1" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
+id="5" predecessors="1" require_predecessor_success="1" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
+id="6" predecessors="2" require_predecessor_success="1" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
+id="7" predecessors="3" require_predecessor_success="1" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
+id="8" predecessors="3" require_predecessor_success="1" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
+id="9" predecessors="5" require_predecessor_success="1" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
+id="10" predecessors="6" require_predecessor_success="1" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
+id="11" predecessors="7" require_predecessor_success="1" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
+id="12" predecessors="8" require_predecessor_success="1" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
+id="13" predecessors="9" require_predecessor_success="1" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
+id="14" predecessors="10" require_predecessor_success="1" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
+id="15" predecessors="11" require_predecessor_success="1" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
+id="16" predecessors="12" require_predecessor_success="1" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
+id="17" predecessors="13" require_predecessor_success="1" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2

--- a/tests/resources/tasks_opt_case3.txt
+++ b/tests/resources/tasks_opt_case3.txt
@@ -1,9 +1,9 @@
-id="1" predecessors="" instance="tm1srv01" process="}bedrock.server.wait" pWaitSec=1
-id="2" predecessors="1" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
-id="3" predecessors="1" instance="tm1srv01" process="}bedrock.server.wait" pWaitSec=3
-id="4" predecessors="1" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=4
-id="5" predecessors="2,3" instance="tm1srv01" process="}bedrock.server.wait" pWaitSec=5
-id="6" predecessors="4,5" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=6
-id="7" predecessors="4" instance="tm1srv01" process="}bedrock.server.wait" pWaitSec=7
-id="8" predecessors="6" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=8
-id="9" predecessors="1" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
+id="1" predecessors="" require_predecessor_success="1" instance="tm1srv01" process="}bedrock.server.wait" pWaitSec=1
+id="2" predecessors="1" require_predecessor_success="1" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
+id="3" predecessors="1" require_predecessor_success="1" instance="tm1srv01" process="}bedrock.server.wait" pWaitSec=3
+id="4" predecessors="1" require_predecessor_success="1" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=4
+id="5" predecessors="2,3" require_predecessor_success="1" instance="tm1srv01" process="}bedrock.server.wait" pWaitSec=5
+id="6" predecessors="4,5" require_predecessor_success="1" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=6
+id="7" predecessors="4" require_predecessor_success="1" instance="tm1srv01" process="}bedrock.server.wait" pWaitSec=7
+id="8" predecessors="6" require_predecessor_success="1" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=8
+id="9" predecessors="1" require_predecessor_success="1" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2

--- a/tests/resources/tasks_opt_case4.txt
+++ b/tests/resources/tasks_opt_case4.txt
@@ -1,9 +1,9 @@
-id="1" predecessors="9" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
-id="2" predecessors="1" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
-id="3" predecessors="2" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
-id="4" predecessors="3" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
-id="5" predecessors="4" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
-id="6" predecessors="5" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
-id="7" predecessors="6" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
-id="8" predecessors="7" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
-id="9" predecessors="" instance="tm1srv01" process="}bedrock.server.wait" pWaitSec=1
+id="1" predecessors="9" require_predecessor_success="1" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
+id="2" predecessors="1" require_predecessor_success="1" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
+id="3" predecessors="2" require_predecessor_success="1" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
+id="4" predecessors="3" require_predecessor_success="1" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
+id="5" predecessors="4" require_predecessor_success="1" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
+id="6" predecessors="5" require_predecessor_success="1" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
+id="7" predecessors="6" require_predecessor_success="1" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
+id="8" predecessors="7" require_predecessor_success="1" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
+id="9" predecessors="" require_predecessor_success="1" instance="tm1srv01" process="}bedrock.server.wait" pWaitSec=1

--- a/tests/resources/tasks_opt_case5.txt
+++ b/tests/resources/tasks_opt_case5.txt
@@ -1,6 +1,6 @@
-id="11" predecessors="" instance="tm1srv01" process="}bedrock.server.wait" pWaitSec=11
-id="12" predecessors="" instance="tm1srv01" process="}bedrock.server.wait" pWaitSec=12
-id="13" predecessors="11,12" instance="tm1srv01" process="}bedrock.server.wait" pWaitSec=13
-id="21" predecessors="" instance="tm1srv01" process="}bedrock.server.wait" pWaitSec=21
-id="22" predecessors="" instance="tm1srv01" process="}bedrock.server.wait" pWaitSec=22
-id="23" predecessors="21,22" instance="tm1srv01" process="}bedrock.server.wait" pWaitSec=23
+id="11" predecessors="" require_predecessor_success="1" instance="tm1srv01" process="}bedrock.server.wait" pWaitSec=11
+id="12" predecessors="" require_predecessor_success="1" instance="tm1srv01" process="}bedrock.server.wait" pWaitSec=12
+id="13" predecessors="11,12" require_predecessor_success="1" instance="tm1srv01" process="}bedrock.server.wait" pWaitSec=13
+id="21" predecessors="" require_predecessor_success="1" instance="tm1srv01" process="}bedrock.server.wait" pWaitSec=21
+id="22" predecessors="" require_predecessor_success="1" instance="tm1srv01" process="}bedrock.server.wait" pWaitSec=22
+id="23" predecessors="21,22" require_predecessor_success="1" instance="tm1srv01" process="}bedrock.server.wait" pWaitSec=23

--- a/tests/resources/tasks_opt_happy_case.txt
+++ b/tests/resources/tasks_opt_happy_case.txt
@@ -1,4 +1,4 @@
-id="1" predecessors="" instance="tm1srv01" process="}bedrock.server.wait" pWaitSec=1
-id="2" predecessors="1" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
-id="3" predecessors="2" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
-id="4" predecessors="3" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
+id="1" predecessors="" require_predecessor_success="1" instance="tm1srv01" process="}bedrock.server.wait" pWaitSec=1
+id="2" predecessors="1" require_predecessor_success="1" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
+id="3" predecessors="2" require_predecessor_success="1" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
+id="4" predecessors="3" require_predecessor_success="1" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2

--- a/tests/resources/tasks_opt_multi_task_per_id.txt
+++ b/tests/resources/tasks_opt_multi_task_per_id.txt
@@ -1,4 +1,4 @@
-id="1" predecessors="" instance="tm1srv01" process="}bedrock.server.wait" pWaitSec=1
-id="2" predecessors="1" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
-id="2" predecessors="1" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=3
-id="3" predecessors="2" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=4
+id="1" predecessors="" require_predecessor_success="1" instance="tm1srv01" process="}bedrock.server.wait" pWaitSec=1
+id="2" predecessors="1" require_predecessor_success="1" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=2
+id="2" predecessors="1" require_predecessor_success="1" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=3
+id="3" predecessors="2" require_predecessor_success="1" instance="tm1srv02" process="}bedrock.server.wait" pWaitSec=4

--- a/utils.py
+++ b/utils.py
@@ -1,6 +1,7 @@
 import os
 import sys
 from enum import Enum
+from typing import List, Dict
 
 
 def set_current_directory():
@@ -16,11 +17,28 @@ def set_current_directory():
     return directory
 
 
+class Wait:
+    def __init__(self):
+        pass
+
+    # useful for testing
+    def __eq__(self, other):
+        if isinstance(other, Wait):
+            return True
+
+        return False
+
+
 class Task:
+    id = 1
+
     def __init__(self, instance_name, process_name, parameters):
+        self.id = Task.id
         self.instance_name = instance_name
         self.process_name = process_name
         self.parameters = parameters
+
+        Task.id = Task.id + 1
 
     def translate_to_line(self):
         return 'instance="{instance}" process="{process}" {parameters}\n'.format(
@@ -30,7 +48,8 @@ class Task:
 
 
 class OptimizedTask(Task):
-    def __init__(self, task_id, instance_name, process_name, parameters, predecessors, require_predecessor_success):
+    def __init__(self, task_id: str, instance_name: str, process_name: str, parameters: Dict, predecessors: List,
+                 require_predecessor_success: bool):
         super().__init__(instance_name, process_name, parameters)
         self.id = task_id
         self.predecessors = predecessors


### PR DESCRIPTION
Using tasks instead lines
Store global mapping of task-id and success
Use global mapping to check if predecessor is successful before run