### PR TITLE
Update rushti.py

### DIFF
--- a/rushti.py
+++ b/rushti.py
@@ -624,7 +624,7 @@ if __name__ == "__main__":
     # setup results variable (guarantee it's not empty in case of error)
     results = list()
     # execution
-    event_loop = asyncio.get_event_loop()
+    event_loop = asyncio.new_event_loop()
     try:
         results = event_loop.run_until_complete(
             work_through_tasks(


### PR DESCRIPTION
Running RushTI with python 3.11.4 was raising an alert.
`  rushti.py:627: DeprecationWarning: There is no current event loop event_loop = asyncio.get_event_loop()`

As found [here](https://stackoverflow.com/questions/73361664/asyncio-get-event-loop-deprecationwarning-there-is-no-current-event-loop), this occur in python 3.11 and require an update. 

Tested locally and this works fine.