### PR TITLE
Add support for HasMinorError result

### DIFF
--- a/rushti.py
+++ b/rushti.py
@@ -226,7 +226,7 @@ def parse_line_arguments(line: str) -> Dict[str, Any]:
         elif key_lower == "succeed_on_minor_errors":
             line_arguments[argument] = value.lower() in TRUE_VALUES
         else:
-            # Store the argument-value pair as is
+            # Directly assign the value without stripping quotes
             line_arguments[argument] = value
 
     return line_arguments
@@ -880,7 +880,5 @@ if __name__ == "__main__":
     exit_rushti(
         overall_success=success,
         executions=len(results),
-        successes=sum(results),
-        start_time=start,
         end_time=end,
         elapsed_time=duration)

--- a/tests/resources/tasks_opt_succeed_on_minors_error.txt
+++ b/tests/resources/tasks_opt_succeed_on_minors_error.txt
@@ -1,0 +1,3 @@
+id="1" predecessors="" require_predecessor_success="1" succeed_on_minor_errors="0" instance="DEVOPS_DEV" process="rushti.process.return" pReturnCode=0
+id="2" predecessors="1" require_predecessor_success="1" succeed_on_minor_errors="1" instance="DEVOPS_DEV" process="rushti.process.return" pReturnCode=1
+id="3" predecessors="2" require_predecessor_success="1" instance="DEVOPS_DEV" process="rushti.process.return" pReturnCode=0

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -186,6 +186,22 @@ class TestParseLineArguments(unittest.TestCase):
             'require_predecessor_success': True
         }
         self.assertEqual(result, expected)
+    
+    def test_sql_query_parsing(self):
+        self.maxDiff = None
+        line = 'id="1" predecessors="" require_predecessor_success="" instance="tm1srv01" process="}bedrock.server.query" pQuery="SELECT Id,IsDeleted FROM Account WHERE date=\\"20241031092120\\"" pParam2="" pParam3="testing\\"2\\""'
+        result = parse_line_arguments(line)
+        expected = {
+            'id': '1',
+            'predecessors': [],
+            'require_predecessor_success': False,
+            'instance': 'tm1srv01',
+            'process': '}bedrock.server.query',
+            'pQuery': 'SELECT Id,IsDeleted FROM Account WHERE date="20241031092120"',
+            'pParam2': '',
+            'pParam3': 'testing"2"'
+        }
+        self.assertEqual(result, expected)
 
 
 class TestSucceedOnMinorErrors(unittest.TestCase):

--- a/utils.py
+++ b/utils.py
@@ -50,11 +50,13 @@ class Task:
 class OptimizedTask(Task):
     def __init__(self, task_id: str, instance_name: str, process_name: str, parameters: Dict[str, Any],
                  predecessors: List,
-                 require_predecessor_success: bool):
+                 require_predecessor_success: bool,
+                 succeed_on_minor_errors: bool = False):
         super().__init__(instance_name, process_name, parameters)
         self.id = task_id
         self.predecessors = predecessors
         self.require_predecessor_success = require_predecessor_success
+        self.succeed_on_minor_errors = succeed_on_minor_errors
         self.successors = list()
 
     @property
@@ -65,11 +67,13 @@ class OptimizedTask(Task):
     def has_successors(self):
         return len(self.successors) > 0
 
+    
     def translate_to_line(self):
-        return 'id="{id}" predecessors="{predecessors}" require_predecessor_success="{require_predecessor_success}" instance="{instance}" process="{process}" {parameters}\n'.format(
+        return 'id="{id}" predecessors="{predecessors}" require_predecessor_success="{require_predecessor_success}" succeed_on_minor_errors="{succeed_on_minor_errors}" instance="{instance}" process="{process}" {parameters}\n'.format(
             id=self.id,
-            predecessors=self.predecessors,
+            predecessors=",".join(map(str, self.predecessors)),
             require_predecessor_success=self.require_predecessor_success,
+            succeed_on_minor_errors=self.succeed_on_minor_errors,
             instance=self.instance_name,
             process=self.process_name,
             parameters=' '.join('{}="{}"'.format(parameter, value) for parameter, value in self.parameters.items()))

--- a/utils.py
+++ b/utils.py
@@ -32,18 +32,20 @@ class Wait:
 class Task:
     id = 1
 
-    def __init__(self, instance_name: str, process_name: str, parameters: Dict[str, Any] = None):
+    def __init__(self, instance_name: str, process_name: str, parameters: Dict[str, Any] = None, succeed_on_minor_errors: bool = False):
         self.id = Task.id
         self.instance_name = instance_name
         self.process_name = process_name
         self.parameters = parameters
+        self.succeed_on_minor_errors = succeed_on_minor_errors
 
         Task.id = Task.id + 1
 
     def translate_to_line(self):
-        return 'instance="{instance}" process="{process}" {parameters}\n'.format(
+        return 'instance="{instance}" process="{process}" succeed_on_minor_errors="{succeed_on_minor_errors}" {parameters}\n'.format(
             instance=self.instance_name,
             process=self.process_name,
+            succeed_on_minor_errors=self.succeed_on_minor_errors,
             parameters=' '.join('{}="{}"'.format(parameter, value) for parameter, value in self.parameters.items()))
 
 
@@ -52,11 +54,10 @@ class OptimizedTask(Task):
                  predecessors: List,
                  require_predecessor_success: bool,
                  succeed_on_minor_errors: bool = False):
-        super().__init__(instance_name, process_name, parameters)
+        super().__init__(instance_name, process_name, parameters, succeed_on_minor_errors)
         self.id = task_id
         self.predecessors = predecessors
         self.require_predecessor_success = require_predecessor_success
-        self.succeed_on_minor_errors = succeed_on_minor_errors
         self.successors = list()
 
     @property


### PR DESCRIPTION
Optional parameter in the OPT task file to consider processes result `HasMinroErrors` as successful if required. Check /tests/resources/tasks_opt_succeed_on_minors_error.txt file for details.
This resolves #86 