### PR TITLE
fixed validation will only run once per unique process instead of once per task

### DIFF
--- a/rushti.py
+++ b/rushti.py
@@ -760,7 +760,7 @@ def validate_tasks(tasks: List[Task], tm1_services: Dict[str, TM1Service]) -> bo
                 logger.error(msg)
                 validation_ok = False
 
-        validated_tasks.append(current_task)
+        validated_tasks.append(current_task["process"])
 
     return validation_ok
 


### PR DESCRIPTION


## Description
A string will never be in a list of dictionaries, so the deduplication never triggers. I changed the list to be strings only.


## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] CI/CD or build changes

## Release Label

<!--
Maintainers: Apply ONE of these labels to trigger a release:
- `release:patch` - Bug fixes, minor improvements (1.5.0 → 1.5.1)
- `release:minor` - New features, non-breaking changes (1.5.0 → 1.6.0)
- `release:major` - Breaking changes (1.5.0 → 2.0.0)

No label = no release (for docs, CI changes, etc.)
-->

## Checklist

- [x] I have tested my changes locally
- [ ] I have updated documentation if needed
- [ ] My code follows the project's coding style
- [ ] I have added tests if applicable
