### PR TITLE
Fix use_keyring support in build command and TM1 integration

### DIFF
--- a/src/rushti/commands.py
+++ b/src/rushti/commands.py
@@ -22,6 +22,7 @@ from typing import Optional
 from TM1py import TM1Service
 
 from rushti.settings import load_settings
+from rushti.tm1_integration import resolve_tm1_params
 from rushti.stats import create_stats_database
 from rushti.taskfile import TaskfileSource
 from rushti.taskfile_ops import (
@@ -106,8 +107,7 @@ Examples:
 
     print(f"Connecting to TM1 instance: {args.tm1_instance}")
     try:
-        params = dict(config[args.tm1_instance])
-        params.pop("session_context", None)
+        params = resolve_tm1_params(config, args.tm1_instance)
         tm1 = TM1Service(**params)
     except Exception as e:
         print(f"Error connecting to TM1: {e}")

--- a/src/rushti/execution.py
+++ b/src/rushti/execution.py
@@ -22,12 +22,12 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple, TYPE_CHECKING
 
-import keyring
 from TM1py import TM1Service
 from TM1py.Exceptions import TM1pyTimeout
 
 from rushti.task import Task, OptimizedTask
 from rushti.dag import DAG
+from rushti.tm1_integration import resolve_tm1_params
 from rushti.messages import (
     MSG_PROCESS_EXECUTE,
     MSG_PROCESS_SUCCESS,
@@ -174,11 +174,6 @@ def setup_tm1_services(
         # handle default values from configparser
         if tm1_server_name != config.default_section:
             try:
-                use_keyring = config.getboolean(tm1_server_name, "use_keyring", fallback=False)
-                if use_keyring:
-                    password = keyring.get_password(tm1_server_name, params.get("user"))
-                    params["password"] = password
-
                 connection_file = config.get(tm1_server_name, "connection_file", fallback=None)
 
                 # restore connection from file. In practice faster than creating a new one
@@ -199,9 +194,9 @@ def setup_tm1_services(
 
                 # case no connection file provided or connection file expired
                 if tm1_server_name not in tm1_services:
-                    params.pop("session_context", None)
+                    resolved_params = resolve_tm1_params(config, tm1_server_name)
                     tm1_services[tm1_server_name] = TM1Service(
-                        **params,
+                        **resolved_params,
                         session_context=session_context,
                         connection_pool_size=max_workers,
                     )

--- a/src/rushti/tm1_integration.py
+++ b/src/rushti/tm1_integration.py
@@ -23,7 +23,6 @@ import logging
 import shlex
 from typing import Any, Dict, List, Optional
 
-import keyring
 import pandas as pd
 from TM1py import TM1Service
 
@@ -87,6 +86,8 @@ def resolve_tm1_params(config: configparser.ConfigParser, instance_name: str) ->
 
     use_keyring_flag = config.getboolean(instance_name, "use_keyring", fallback=False)
     if use_keyring_flag:
+        import keyring
+
         password = keyring.get_password(instance_name, params.get("user"))
         if password:
             params["password"] = password

--- a/src/rushti/tm1_integration.py
+++ b/src/rushti/tm1_integration.py
@@ -23,6 +23,7 @@ import logging
 import shlex
 from typing import Any, Dict, List, Optional
 
+import keyring
 import pandas as pd
 from TM1py import TM1Service
 
@@ -71,6 +72,37 @@ ALL_MEASURES = [
 ]
 
 
+def resolve_tm1_params(config: configparser.ConfigParser, instance_name: str) -> dict:
+    """Resolve TM1 connection params from config, handling use_keyring and cleanup.
+
+    Reads the raw config section, resolves the password via keyring if
+    ``use_keyring`` is enabled, and strips non-TM1Service params so the
+    result can be passed directly to ``TM1Service(**params)``.
+
+    :param config: Parsed ConfigParser with TM1 instance sections
+    :param instance_name: Section name in the config
+    :return: Clean dict of kwargs suitable for TM1Service
+    """
+    params = dict(config[instance_name])
+
+    use_keyring_flag = config.getboolean(instance_name, "use_keyring", fallback=False)
+    if use_keyring_flag:
+        password = keyring.get_password(instance_name, params.get("user"))
+        if password:
+            params["password"] = password
+        else:
+            logger.warning(
+                f"use_keyring is enabled for '{instance_name}' but no password found in keyring"
+            )
+
+    # Remove params that are not TM1Service kwargs
+    params.pop("use_keyring", None)
+    params.pop("session_context", None)
+    params.pop("connection_file", None)
+
+    return params
+
+
 def connect_to_tm1_instance(
     instance_name: str,
     config_path: str,
@@ -96,8 +128,7 @@ def connect_to_tm1_instance(
         )
 
     try:
-        params = dict(config[instance_name])
-        params.pop("session_context", None)
+        params = resolve_tm1_params(config, instance_name)
         tm1 = TM1Service(**params)
         logger.info(f"Connected to TM1 instance: {instance_name}")
         return tm1

--- a/tests/unit/test_tm1_integration.py
+++ b/tests/unit/test_tm1_integration.py
@@ -124,6 +124,8 @@ class TestConnectToTM1Instance(unittest.TestCase):
             "user": "admin",
             "password": "apple",
         }
+        mock_config.getboolean.return_value = False
+        mock_config.get.return_value = None
         mock_config_parser.return_value = mock_config
 
         # Setup mock TM1Service


### PR DESCRIPTION
## Summary
- Fixes #129: `use_keyring` config option was only handled in the main execution path but missing from `rushti build` and `connect_to_tm1_instance`
- Extracts a shared `resolve_tm1_params()` helper in `tm1_integration.py` that centralizes keyring password resolution and non-TM1Service param cleanup (`use_keyring`, `session_context`, `connection_file`)
- All three TM1 connection paths now go through the same logic, preventing future inconsistencies

## Test plan
- [ ] Run `rushti build` with `use_keyring=true` in config.ini and verify cube/dimension creation succeeds
- [ ] Run a workflow from the RushTI cube (`--tm1-instance` with `use_keyring=true`) and verify task execution succeeds
- [ ] Run standard task execution (from file) with `use_keyring=true` and verify it still works
- [ ] Run standard task execution with `password` directly in config (no keyring) and verify no regression
- [ ] Unit tests pass: `python -m pytest tests/unit/ -x -q`

🤖 Generated with [Claude Code](https://claude.com/claude-code)