### PR TITLE
Fix early-release regression: avoid double-logout on same TM1 session

### DIFF
--- a/src/rushti/execution.py
+++ b/src/rushti/execution.py
@@ -588,7 +588,6 @@ async def work_through_tasks_dag(
     loop = asyncio.get_event_loop()
     task_start_times: Dict[str, datetime] = {}
     # Track instances that have been early-released to avoid double-logout
-    released_instances: set = set()
 
     with ThreadPoolExecutor(int(max_workers)) as executor:
         # Map futures to tasks
@@ -689,18 +688,21 @@ async def work_through_tasks_dag(
             # Only active when tm1_preserve_connections is provided (i.e. called from CLI).
             # Direct callers (e.g. integration tests) that don't pass it won't trigger
             # early release, preserving shared connection state across test methods.
+            #
+            # _logout_instance removes the entry from tm1_services on success, so the
+            # end-of-run logout() call cannot double-logout the same session (which
+            # would otherwise emit a CookieConflictError warning when the second
+            # logout response leaves a duplicate TM1SessionId in the cookie jar).
             if tm1_preserve_connections is not None:
                 remaining = dag.get_remaining_tasks_by_instance()
                 for instance_name in list(tm1_services.keys()):
-                    if instance_name not in remaining and instance_name not in released_instances:
-                        released = _logout_instance(
+                    if instance_name not in remaining:
+                        _logout_instance(
                             instance_name,
                             tm1_services,
                             tm1_preserve_connections,
                             force_logout,
                         )
-                        if released:
-                            released_instances.add(instance_name)
 
             # Submit newly ready tasks
             submit_ready_tasks()
@@ -718,17 +720,19 @@ def _logout_instance(
     tm1_preserve_connections: Dict,
     force: bool = False,
 ):
-    """Logout from a single TM1 instance.
+    """Logout from a single TM1 instance and remove it from ``tm1_services``.
 
     Used for early session release when an instance has no remaining tasks.
-    Does NOT remove the instance from tm1_services — the caller tracks
-    which instances have been released to avoid double-release.
+    On success the instance is removed from ``tm1_services`` so that the
+    end-of-run :func:`logout` call cannot double-logout the same session.
+    On failure or when skipped (preserved without force), the entry stays
+    so the final cleanup retries it.
 
     :param instance_name: Name of the TM1 instance to logout from
-    :param tm1_services: Dictionary of TM1Service instances
+    :param tm1_services: Dictionary of TM1Service instances (mutated on success)
     :param tm1_preserve_connections: Dictionary indicating which connections to preserve
     :param force: If True, logout even from preserved connections
-    :return: True if logout was performed, False if skipped
+    :return: True if logout was performed, False if skipped or failed
     """
     if instance_name not in tm1_services:
         return False
@@ -739,6 +743,7 @@ def _logout_instance(
 
     try:
         tm1_services[instance_name].logout()
+        del tm1_services[instance_name]
         logger.info(f"Early session release: logged out from {instance_name} (no remaining tasks)")
         return True
     except Exception as e:
@@ -751,15 +756,21 @@ def logout(
     tm1_preserve_connections: Dict,
     force: bool = False,
 ):
-    """Logout from all TM1 instances.
+    """Logout from all remaining TM1 instances and remove them from ``tm1_services``.
 
-    :param tm1_services: Dictionary of TM1Service instances
+    Successfully logged-out instances are removed from ``tm1_services`` so
+    the dict consistently represents *live* connections. Pre-existing
+    entries that were already released via :func:`_logout_instance` are
+    therefore not double-logged-out — they're not in the dict anymore.
+
+    :param tm1_services: Dictionary of TM1Service instances (mutated)
     :param tm1_preserve_connections: Dictionary indicating which connections to preserve
     :param force: If True, logout from ALL connections including preserved ones.
                   Use this for exclusive mode to ensure sessions are properly closed.
     :return: None
     """
-    for connection in tm1_services:
+    # Snapshot keys so del-on-success doesn't perturb iteration.
+    for connection in list(tm1_services.keys()):
         # Skip preserved connections unless force is True
         if not force and tm1_preserve_connections.get(connection, False) is True:
             logger.debug(f"Preserving connection to {connection}")
@@ -767,6 +778,7 @@ def logout(
 
         try:
             tm1_services[connection].logout()
+            del tm1_services[connection]
             logger.debug(f"Logged out from {connection}")
         except Exception as e:
             logger.warning(f"Failed to logout from {connection}: {e}")

--- a/tests/unit/test_early_session_release.py
+++ b/tests/unit/test_early_session_release.py
@@ -25,6 +25,7 @@ from rushti.task import Task  # noqa: E402
 from rushti.execution import (  # noqa: E402
     work_through_tasks_dag,
     _logout_instance,
+    logout,
     ExecutionContext,
 )
 
@@ -130,7 +131,7 @@ class TestLogoutInstance(unittest.TestCase):
     """Tests for _logout_instance() helper."""
 
     def test_logout_calls_logout_and_returns_true(self):
-        """Successful logout calls logout on the service and returns True."""
+        """Successful logout calls logout, removes the entry, returns True."""
         mock_tm1 = MagicMock()
         services = {"A": mock_tm1, "B": MagicMock()}
 
@@ -138,7 +139,19 @@ class TestLogoutInstance(unittest.TestCase):
 
         mock_tm1.logout.assert_called_once()
         self.assertTrue(result)
-        # Dict is NOT modified — caller tracks released instances separately
+        # On success the entry is removed so end-of-run logout() can't double-release.
+        self.assertNotIn("A", services)
+        self.assertIn("B", services)
+
+    def test_logout_failure_keeps_entry_in_services(self):
+        """A failed logout leaves the entry so the final cleanup can retry."""
+        mock_tm1 = MagicMock()
+        mock_tm1.logout.side_effect = Exception("boom")
+        services = {"A": mock_tm1}
+
+        result = _logout_instance("A", services, {}, force=False)
+
+        self.assertFalse(result)
         self.assertIn("A", services)
 
     def test_preserved_connection_skipped_without_force(self):
@@ -253,10 +266,16 @@ class TestEarlySessionRelease(unittest.TestCase):
         )
 
         self.assertTrue(all(results))
-        # A should have been logged out early
+        # A should have been logged out early (after its single task finishes,
+        # while B is still running). B is then released after its last task
+        # finishes inside the same loop.
         mock_a.logout.assert_called_once()
-        # Services dict is NOT modified (instances tracked via released_instances set)
-        self.assertIn("A", services)
+        mock_b.logout.assert_called_once()
+        # On successful early release the entry is removed from tm1_services
+        # so that the end-of-run logout() call cannot double-logout the same
+        # session (which would emit a CookieConflictError warning).
+        self.assertNotIn("A", services)
+        self.assertNotIn("B", services)
 
     def test_single_instance_early_release(self):
         """All tasks on one instance: logout once all tasks complete."""
@@ -377,6 +396,121 @@ class TestEarlySessionRelease(unittest.TestCase):
         self.assertEqual(len(results), 3)
         # A should have been released early after A1 completed
         mock_a.logout.assert_called_once()
+
+
+class TestNoDoubleLogoutAfterEarlyRelease(unittest.TestCase):
+    """Regression tests: early release + final logout must not double-logout the same session.
+
+    Before the fix, early session release left the entry in tm1_services
+    after calling .logout(). The end-of-run logout() call (from cli.py's
+    finally block) then iterated the same dict and called .logout()
+    again. The second logout response added a TM1SessionId cookie with
+    different (path, domain, secure) attributes than the original — RFC
+    6265 says that's a distinct cookie — and TM1py's name-only cookie
+    lookup tripped on the duplicate, surfacing as:
+
+        WARNING - Failed to logout from tm1srv01:
+                  There are multiple cookies with name, 'TM1SessionId'
+
+    These tests pin the behavior end-to-end: each session is logged out
+    exactly once, regardless of whether the release came from the early
+    path or the end-of-run path.
+    """
+
+    def _build_mock_execute_task(self):
+        def mock_execute_task(ctx, task, retries, tm1_services):
+            time.sleep(0.005)
+            return True
+
+        return mock_execute_task
+
+    def _run_full_lifecycle(self, dag, services, preserve=None, force_logout=False):
+        """Run work_through_tasks_dag then the end-of-run logout, like cli.py does."""
+        preserve = preserve if preserve is not None else {}
+        with patch("rushti.execution.execute_task", self._build_mock_execute_task()):
+            loop = asyncio.new_event_loop()
+            try:
+                results = loop.run_until_complete(
+                    work_through_tasks_dag(
+                        ExecutionContext(),
+                        dag,
+                        4,
+                        0,
+                        services,
+                        tm1_preserve_connections=preserve,
+                        force_logout=force_logout,
+                    )
+                )
+            finally:
+                loop.close()
+        # Mirrors the cli.py finally block: logout(tm1_service_by_instance, preserve_connections, ...)
+        logout(services, preserve, force=force_logout)
+        return results
+
+    def test_single_instance_logged_out_exactly_once(self):
+        """Bug scenario: single-instance workflow ran twice through logout pre-fix."""
+        dag = DAG()
+        dag.add_task(_make_task("1", instance="tm1srv01"))
+        dag.add_task(_make_task("2", instance="tm1srv01"))
+
+        mock_tm1 = MagicMock()
+        services = {"tm1srv01": mock_tm1}
+
+        self._run_full_lifecycle(dag, services)
+
+        # Pre-fix: called_count == 2 (once in early release, once in final logout).
+        # Post-fix: exactly once.
+        self.assertEqual(mock_tm1.logout.call_count, 1)
+        self.assertNotIn("tm1srv01", services)
+
+    def test_multi_instance_each_logged_out_exactly_once(self):
+        """Both early-released and final-released instances logout exactly once."""
+        dag = DAG()
+        dag.add_task(_make_task("1", instance="A"))
+        dag.add_task(_make_task("2", instance="B"))
+
+        mock_a = MagicMock()
+        mock_b = MagicMock()
+        services = {"A": mock_a, "B": mock_b}
+
+        self._run_full_lifecycle(dag, services)
+
+        self.assertEqual(mock_a.logout.call_count, 1)
+        self.assertEqual(mock_b.logout.call_count, 1)
+        self.assertEqual(services, {})
+
+    def test_failed_early_release_falls_back_to_final_logout(self):
+        """If early release raises, the entry stays so final logout retries.
+
+        This preserves the existing safety net: a transient logout failure
+        during early release shouldn't leave the session orphaned.
+        """
+        dag = DAG()
+        dag.add_task(_make_task("1", instance="tm1srv01"))
+
+        mock_tm1 = MagicMock()
+        mock_tm1.logout.side_effect = [Exception("transient"), None]
+        services = {"tm1srv01": mock_tm1}
+
+        self._run_full_lifecycle(dag, services)
+
+        # Two attempts: failed early release, successful final logout.
+        self.assertEqual(mock_tm1.logout.call_count, 2)
+        self.assertNotIn("tm1srv01", services)
+
+    def test_preserved_without_force_skips_both_paths(self):
+        """A preserved connection without force is skipped by both passes."""
+        dag = DAG()
+        dag.add_task(_make_task("1", instance="A"))
+
+        mock_a = MagicMock()
+        services = {"A": mock_a}
+        preserve = {"A": True}
+
+        self._run_full_lifecycle(dag, services, preserve=preserve, force_logout=False)
+
+        mock_a.logout.assert_not_called()
+        self.assertIn("A", services)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes a regression introduced in [v2.1.0](https://github.com/cubewise-code/rushti/compare/v2.0.5...v2.1.0) by the early-session-release feature ([#135](https://github.com/cubewise-code/rushti/issues/135) / [#136](https://github.com/cubewise-code/rushti/pull/136)).

Every `rushti run` against a single-instance workflow has been emitting this warning at the end of the run since v2.1.0:

```
WARNING - Failed to logout from tm1srv01: There are multiple cookies with name, 'TM1SessionId'
```

The workflow itself succeeds; the warning is end-of-run logout cleanup noise — but it's persistent and confusing. Multi-instance workflows hit it too whenever an instance finishes its tasks before the workflow as a whole.

## Root cause

`_logout_instance` (added in v2.1.0) calls `tm1_services[name].logout()` for early release but **does not remove the entry from `tm1_services`** afterward. The end-of-run `logout()` call in `cli.py`'s finally block then iterates the same dict and calls `.logout()` again on the same `TM1Service` instance.

Two logouts on the same `requests.Session`:

```
LOGOUT #1 (early release)        LOGOUT #2 (end-of-run cleanup)
        |                                 |
        v                                 v
DELETE /api/v1/ActiveSession      DELETE /api/v1/ActiveSession
        |                                 |
   server replies                    server replies, the response now
   normally                          appends a TM1SessionId cookie
   single cookie in jar              with different (Path, Domain,
                                     Secure) attributes — RFC 6265
                                     stores it as a distinct cookie
                                     |
                                     v
                              TM1py's name-only lookup
                              `cookies.get("TM1SessionId")`
                              raises CookieConflictError
                                     |
                                     v
                              caught at execution.py:772
                              → WARNING emitted
```

This was confirmed locally by reproducing the duplicate cookie state with a minimal diagnostic — single cookie before logout, two cookies after a second logout call on the same session. Single-logout flows (e.g. `read_taskfile_from_tm1`) work cleanly; only the early-release path triggers the double-logout pattern.

## The fix (Option A)

On a successful logout — both in `_logout_instance` and in the end-of-run `logout()` — remove the entry from `tm1_services`. The dict now consistently represents **live** connections, and the end-of-run pass naturally skips anything already released. Failed logouts still leave the entry in place so the end-of-run cleanup retries them (existing safety net preserved).

The redundant `released_instances` tracking set in `work_through_tasks_dag` is removed — the dict mutation IS the tracking mechanism now.

### Diff shape

- `src/rushti/execution.py`
  - `_logout_instance` now `del tm1_services[instance_name]` on success; docstring updated.
  - `logout` (end-of-run) does the same; iterates `list(tm1_services.keys())` for safety.
  - `work_through_tasks_dag` drops the `released_instances` set and the redundant membership guard.

- `tests/unit/test_early_session_release.py`
  - Existing tests that asserted the old "entry stays" behavior updated to assert "entry removed".
  - New `TestNoDoubleLogoutAfterEarlyRelease` class with **4 regression tests** that mirror the actual cli.py lifecycle (`work_through_tasks_dag` → `logout`) and pin:
    - single-instance: `mock_tm1.logout.call_count == 1` (was 2 pre-fix)
    - multi-instance: each instance logs out exactly once
    - failed early release falls back to final logout (retry behavior preserved)
    - preserved + no-force is skipped by both passes

## Test plan

- [x] 23 tests in `test_early_session_release.py` pass (4 new, 19 existing/updated)
- [x] Full unit suite: 612 passed, 5 skipped
- [x] `ruff check` clean
- [x] `black --check` clean
- [x] CI Unit Tests pass (Python 3.9, 3.13)
- [x] CI Integration Tests pass (TM1-required, ~7 min)
- [x] Manual: `rushti run` against a single-instance workflow no longer prints the cookie warning

## Compatibility

- No CLI surface change.
- No public-API change. `_logout_instance` is module-private (leading underscore); the public `logout` function keeps the same signature, only adds `del` on success — callers that handed in `tm1_services` and didn't reuse it after `logout` returns are unaffected.
- Behavior change is exactly what the original v2.1.0 PR intended: each session is logged out once, no orphan double-logouts.

Suggested release: 2.1.1 (patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)