### PR TITLE
Ship v11- and v12-aware }rushti.load.results TI (closes #154)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to RushTI are documented in this file.
 
+## Unreleased — `feat/issue-154-v12-load-results`
+
+- Fix: `rushti build` now installs a TM1-version-aware `}rushti.load.results`
+  TI (closes #154). On v12 targets the body no longer references the removed
+  `CubeGetLogChanges` / `CubeSetLogChanges` / `ExecuteCommand` functions;
+  source-file cleanup uses the TM1-native `ASCIIDelete` instead of shelling
+  out via `cmd /c del`. The v11 body is unchanged.
+
 ## Unreleased — `feat/issue-146-detailed-results`
 
 - Add `--detailed-results` for per-execution cube rows (closes #146).

--- a/src/rushti/tm1_build.py
+++ b/src/rushti/tm1_build.py
@@ -32,16 +32,19 @@ from TM1py.Objects import (
     Process,
     Subset,
 )
+from TM1py.Utils import integerize_version
 
 from rushti.tm1_objects import (
     MEASURE_ATTRIBUTES,
     MEASURE_ELEMENTS,
     PROCESS_DATA,
     PROCESS_DATASOURCE,
-    PROCESS_EPILOG,
+    PROCESS_EPILOG_V11,
+    PROCESS_EPILOG_V12,
     PROCESS_METADATA,
     PROCESS_PARAMETERS,
-    PROCESS_PROLOG,
+    PROCESS_PROLOG_V11,
+    PROCESS_PROLOG_V12,
     PROCESS_VARIABLES,
     RUN_ID_SEED_ELEMENTS,
     SAMPLE_DATA,
@@ -558,12 +561,16 @@ def _create_process(tm1: TM1Service, process_name: str, force: bool = False) -> 
         logger.info(f"Replacing existing process: {process_name}")
         tm1.processes.delete(process_name)
 
+    is_v12 = integerize_version(tm1.version, 2) >= 12
+    prolog = PROCESS_PROLOG_V12 if is_v12 else PROCESS_PROLOG_V11
+    epilog = PROCESS_EPILOG_V12 if is_v12 else PROCESS_EPILOG_V11
+
     process = Process(
         name=process_name,
-        prolog_procedure=PROCESS_PROLOG,
+        prolog_procedure=prolog,
         metadata_procedure=PROCESS_METADATA,
         data_procedure=PROCESS_DATA,
-        epilog_procedure=PROCESS_EPILOG,
+        epilog_procedure=epilog,
         datasource_type=PROCESS_DATASOURCE["Type"],
         datasource_ascii_decimal_separator=PROCESS_DATASOURCE["asciiDecimalSeparator"],
         datasource_ascii_delimiter_char=PROCESS_DATASOURCE["asciiDelimiterChar"],

--- a/src/rushti/tm1_objects.py
+++ b/src/rushti/tm1_objects.py
@@ -10,8 +10,14 @@ Object Definitions:
     - TASK_ID_ELEMENT_COUNT: Number of elements to generate for task_id dimension (1..N)
     - RUN_ID_SEED_ELEMENTS: Seed elements for run_id dimension
     - WORKFLOW_SEED_ELEMENTS: Seed elements for workflow dimension
-    - PROCESS_DEFINITION: Full TI process definition for }rushti.load.results
+    - PROCESS_PROLOG_V11 / PROCESS_PROLOG_V12: Prolog body per TM1 major version
+    - PROCESS_EPILOG_V11 / PROCESS_EPILOG_V12: Epilog body per TM1 major version
     - SAMPLE_DATA: Sample cube data for demonstration taskfiles
+
+The v12 variants drop calls to functions that were removed or are unsupported
+on TM1 v12 (``CubeGetLogChanges`` / ``CubeSetLogChanges`` and
+``ExecuteCommand``). Source-file cleanup on v12 is handled by the TM1-native
+``ASCIIDelete`` instead of shelling out to ``cmd /c del``.
 """
 
 # ---------------------------------------------------------------------------
@@ -85,7 +91,7 @@ WORKFLOW_SEED_ELEMENTS = ["Sample_Stage_Mode", "Sample_Optimal_Mode"]
 # TI Process: }rushti.load.results
 # ---------------------------------------------------------------------------
 
-PROCESS_PROLOG = r"""#################################################################################################
+PROCESS_PROLOG_V11 = r"""#################################################################################################
 ##~~Join the bedrock TM1 community on GitHub https://github.com/cubewise-code/bedrock Ver 4.0~~##
 #################################################################################################
 
@@ -222,6 +228,142 @@ EndIf;
 #################################################################################################
 """
 
+# v12 prolog: identical to v11 except the CubeGetLogChanges / CubeSetLogChanges
+# block is removed. Those functions are unsupported on TM1 v12 and would cause
+# the TI to fail at compile time.
+PROCESS_PROLOG_V12 = r"""#################################################################################################
+##~~Join the bedrock TM1 community on GitHub https://github.com/cubewise-code/bedrock Ver 4.0~~##
+#################################################################################################
+
+#****Begin: Generated Statements***
+#****End: Generated Statements****
+
+#################################################################################################
+### CHANGE HISTORY:
+### MODIFICATION DATE 	CHANGED BY 	    COMMENT
+### 2026-01-15 		    Nicolas Bisurgi 	Creation of Process
+### YYYY-MM-DD 		    Developer Name 	Reason for modification here
+#################################################################################################
+#Region @DOC
+# Description:
+# This process will load RushTI result files into a TM1 cube
+
+# Use case:
+# Storing RushTI execution stats in a TM1 Cube
+
+# Note:
+# * This process assumes a there is a rushti compliant cube and dimensions. If you don't have it
+# * please run: rushti.py build --tm1-instance tm1srv01
+#EndRegion @DOC
+#################################################################################################
+
+#################################################################################################
+#Region Process Declarations
+### Process Parameters
+# a short description of what the process does goes here in cAction variable, e.g. "copied data from cube A to cube B". This will be written to the message log if pLogOutput=1
+cAction             = 'loading rushti stats into ' | pTargetCube;
+cParamArray         = '';
+# to use the parameter array remove the line above and uncomment the line below, adding the needed parameters in the provided format
+#cParamArray         = 'pLogOutput:%pLogOutput%, pTemp:%pTemp%';
+
+### Global Variables
+StringGlobalVariable('sProcessReturnCode');
+NumericGlobalVariable('nProcessReturnCode');
+
+### Standard Constants
+cThisProcName       = GetProcessName();
+cUserName           = TM1User();
+cTimeStamp          = TimSt( Now, '\Y\m\d\h\i\s' );
+cRandomInt          = NumberToString( INT( RAND( ) * 1000 ));
+cTempObjName        = Expand('%cThisProcName%_%cTimeStamp%_%cRandomInt%');
+cViewClr            = '}bedrock_clear_' | cTempObjName;
+cViewSrc            = '}bedrock_source_' | cTempObjName;
+cMsgErrorLevel      = 'ERROR';
+cMsgErrorContent    = 'Process:%cThisProcName% ErrorMsg:%sMessage%';
+cLogInfo            = 'Process:%cThisProcName% run with parameters %cParamArray%';
+sDelimEleStart      = '¦';
+sDelimDim           = '&';
+sDelimEle           = '+';
+nProcessReturnCode  = 0;
+nErrors             = 0;
+nMetadataRecordCount= 0;
+nDataRecordCount    = 0;
+
+### Process Specific Constants
+cFileSrc            = pSourceFile;
+cCubeTgt            = pTargetCube;
+
+#EndRegion Process Declarations
+#################################################################################################
+
+### LogOutput parameters
+IF( pLogoutput = 1 );
+    LogOutput('INFO', Expand( cLogInfo ) );
+ENDIF;
+
+#################################################################################################
+#Region Validate Parameters
+
+# pLogOutput
+If( pLogOutput >= 1 );
+    pLogOutput = 1;
+Else;
+    pLogOutput = 0;
+EndIf;
+
+# Validate source file
+If( Trim( cFileSrc ) @= '' );
+    nErrors = nErrors + 1;
+    sMessage = 'No source cfileube specified.';
+    LogOutput( cMsgErrorLevel, Expand( cMsgErrorContent ) );
+ElseIf( FileExists( cFileSrc ) = 0 );
+    nErrors = nErrors + 1;
+    sMessage = Expand( 'Invalid source file specified: %cFileSrc%.');
+    LogOutput( cMsgErrorLevel, Expand( cMsgErrorContent ) );
+EndIf;
+
+# Validate target cube
+If( Trim( cCubeTgt ) @= '' );
+    nErrors = nErrors + 1;
+    sMessage = 'No target cube specified.';
+    LogOutput( cMsgErrorLevel, Expand( cMsgErrorContent ) );
+ElseIf( CubeExists( cCubeTgt ) = 0 );
+    nErrors = nErrors + 1;
+    sMessage = Expand( 'Invalid target cube specified: %cCubeTgt%.');
+    LogOutput( cMsgErrorLevel, Expand( cMsgErrorContent ) );
+EndIf;
+
+# If any parameters fail validation then set data source of process to null and go directly to epilog
+If( nErrors > 0 );
+    DataSourceType = 'NULL';
+    If( pStrictErrorHandling = 1 );
+        ProcessQuit;
+    Else;
+        ProcessBreak;
+    EndIf;
+EndIf;
+
+#################################################################################################
+#EndRegion Validate Parameters
+
+#################################################################################################
+#Region - DataSource
+
+
+### Assign data source
+If( nErrors = 0 );
+    DatasourceType          = 'CHARACTERDELIMITED';
+    DatasourceNameForServer = cFileSrc;
+    DatasourceASCIIHeaderRecords = 1;
+    DatasourceASCIIDelimiter=',';
+    DatasourceASCIIDecimalSeparator='.';
+    DatasourceASCIIThousandSeparator='';
+EndIf;
+
+#EndRegion - DataSource
+#################################################################################################
+"""
+
 PROCESS_METADATA = r"""#****Begin: Generated Statements***
 #****End: Generated Statements****
 
@@ -271,7 +413,7 @@ CellPutS(vsucceed_on_minor_errors, pTargetCube, vworkflow, vrun_id, vtask_id, 's
 CellPutS(voriginal_task_id, pTargetCube, vworkflow, vrun_id, vtask_id, 'original_task_id');
 """
 
-PROCESS_EPILOG = r"""#################################################################################################
+PROCESS_EPILOG_V11 = r"""#################################################################################################
 ##~~Join the bedrock TM1 community on GitHub https://github.com/cubewise-code/bedrock Ver 4.0~~##
 #################################################################################################
 
@@ -287,6 +429,42 @@ endif;
 
 ### If required switch transaction logging back on
 CubeSetLogChanges( cCubeTgt, nCubeLogChanges );
+
+### Return code & final error message handling
+If( nErrors > 0 );
+    sMessage = 'the process incurred at least 1 error. Please see above lines in this file for more details.';
+    nProcessReturnCode = 0;
+    LogOutput( cMsgErrorLevel, Expand( cMsgErrorContent ) );
+    sProcessReturnCode = Expand( '%sProcessReturnCode% Process:%cThisProcName% completed with errors. Check tm1server.log for details.' );
+    If( pStrictErrorHandling = 1 );
+        ProcessQuit;
+    EndIf;
+Else;
+    sProcessAction = Expand( 'Process:%cThisProcName% successfully %cAction%. %nDataRecordCount% records processed.' );
+    sProcessReturnCode = Expand( '%sProcessReturnCode% %sProcessAction%' );
+    nProcessReturnCode = 1;
+    If( pLogoutput = 1 );
+        LogOutput('INFO', Expand( sProcessAction ) );
+    EndIf;
+EndIf;
+
+### End Epilog ###"""
+
+# v12 epilog: source-file cleanup uses TM1-native ASCIIDelete (no shell-out),
+# and the CubeSetLogChanges restore is omitted because the v12 prolog does not
+# toggle transaction logging.
+PROCESS_EPILOG_V12 = r"""#################################################################################################
+##~~Join the bedrock TM1 community on GitHub https://github.com/cubewise-code/bedrock Ver 4.0~~##
+#################################################################################################
+
+#****Begin: Generated Statements***
+#****End: Generated Statements****
+
+### If required delete the source file
+if(pDeleteSourceFile=1);
+  Sleep(1000);
+  ASCIIDelete(pSourceFile);
+endif;
 
 ### Return code & final error message handling
 If( nErrors > 0 );

--- a/tests/integration/test_v11_v12_results.py
+++ b/tests/integration/test_v11_v12_results.py
@@ -133,6 +133,62 @@ class TestResultPushV11(unittest.TestCase):
         )
         self.assertTrue(success)
 
+    def test_auto_load_results(self):
+        """Push CSV then call }rushti.load.results on v11 (legacy body path)."""
+        with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+            db_path = f.name
+
+        stats_db = None
+        try:
+            stats_db = StatsDatabase(db_path=db_path, enabled=True)
+            run_id = "test_autoload_v11_" + datetime.now().strftime("%Y%m%d_%H%M%S")
+            workflow = "test-autoload-v11"
+
+            stats_db.start_run(run_id=run_id, workflow=workflow)
+            stats_db.record_task(
+                run_id=run_id,
+                task_id="task1",
+                instance=self.INSTANCE,
+                process="}bedrock.server.wait",
+                parameters={"pWaitSec": "1"},
+                success=True,
+                start_time=datetime.now(),
+                end_time=datetime.now() + timedelta(seconds=1),
+                retry_count=0,
+                error_message=None,
+                workflow=workflow,
+            )
+            stats_db.complete_run(run_id=run_id, success_count=1, failure_count=0)
+
+            results_df = build_results_dataframe(stats_db, workflow, run_id)
+            file_name = upload_results_to_tm1(self.tm1, workflow, run_id, results_df)
+
+            if not self.tm1.processes.exists("}rushti.load.results"):
+                self.skipTest("}rushti.load.results process not found on TM1 instance")
+
+            # v11 file paths need .blb to be locatable by the TI's CHARACTERDELIMITED source.
+            version = integerize_version(self.tm1.version, 2)
+            load_file_name = file_name + ".blb" if version < 12 else file_name
+
+            success, status, error_log = self.tm1.processes.execute_with_return(
+                "}rushti.load.results",
+                pSourceFile=load_file_name,
+                pTargetCube="rushti",
+            )
+            self.assertTrue(
+                success,
+                f"}}rushti.load.results failed on v11 (status={status}, error_log={error_log})",
+            )
+
+            try:
+                self.tm1.files.delete(file_name)
+            except Exception:
+                pass
+        finally:
+            if stats_db is not None:
+                stats_db.close()
+            os.unlink(db_path)
+
 
 @pytest.mark.requires_tm1
 @pytest.mark.integration

--- a/tests/integration/tm1_setup.py
+++ b/tests/integration/tm1_setup.py
@@ -87,22 +87,29 @@ def ensure_load_results_process(
         return False
 
     from TM1py.Objects import Process
+    from TM1py.Utils import integerize_version
     from rushti.tm1_objects import (
         PROCESS_DATA,
         PROCESS_DATASOURCE,
-        PROCESS_EPILOG,
+        PROCESS_EPILOG_V11,
+        PROCESS_EPILOG_V12,
         PROCESS_METADATA,
         PROCESS_PARAMETERS,
-        PROCESS_PROLOG,
+        PROCESS_PROLOG_V11,
+        PROCESS_PROLOG_V12,
         PROCESS_VARIABLES,
     )
 
+    is_v12 = integerize_version(tm1.version, 2) >= 12
+    prolog = PROCESS_PROLOG_V12 if is_v12 else PROCESS_PROLOG_V11
+    epilog = PROCESS_EPILOG_V12 if is_v12 else PROCESS_EPILOG_V11
+
     process = Process(
         name=process_name,
-        prolog_procedure=PROCESS_PROLOG,
+        prolog_procedure=prolog,
         metadata_procedure=PROCESS_METADATA,
         data_procedure=PROCESS_DATA,
-        epilog_procedure=PROCESS_EPILOG,
+        epilog_procedure=epilog,
         datasource_type=PROCESS_DATASOURCE["Type"],
         datasource_ascii_decimal_separator=PROCESS_DATASOURCE["asciiDecimalSeparator"],
         datasource_ascii_delimiter_char=PROCESS_DATASOURCE["asciiDelimiterChar"],

--- a/tests/unit/test_tm1_build.py
+++ b/tests/unit/test_tm1_build.py
@@ -239,6 +239,7 @@ class TestProcessAlwaysOverwrites(unittest.TestCase):
 
     def test_existing_process_is_replaced(self):
         mock_tm1 = Mock()
+        mock_tm1.version = "11.8.02200.2"
         mock_tm1.processes.exists.return_value = True
 
         result = _create_process(mock_tm1, "}rushti.load.results", force=False)
@@ -251,6 +252,7 @@ class TestProcessAlwaysOverwrites(unittest.TestCase):
 
     def test_missing_process_is_created(self):
         mock_tm1 = Mock()
+        mock_tm1.version = "11.8.02200.2"
         mock_tm1.processes.exists.return_value = False
 
         result = _create_process(mock_tm1, "}rushti.load.results", force=False)
@@ -258,6 +260,54 @@ class TestProcessAlwaysOverwrites(unittest.TestCase):
         self.assertTrue(result)
         mock_tm1.processes.delete.assert_not_called()
         mock_tm1.processes.create.assert_called_once()
+
+
+class TestProcessBodyVersionSelection(unittest.TestCase):
+    """_create_process picks v11 vs v12 body based on TM1Service.version."""
+
+    # Symbols that must not appear in a v12 body — they're removed/unsupported.
+    V12_FORBIDDEN = ("CubeGetLogChanges", "CubeSetLogChanges", "ExecuteCommand")
+
+    def _build_against(self, version: str):
+        mock_tm1 = Mock()
+        mock_tm1.version = version
+        mock_tm1.processes.exists.return_value = False
+
+        _create_process(mock_tm1, "}rushti.load.results", force=False)
+
+        process = mock_tm1.processes.create.call_args.args[0]
+        return process
+
+    def test_v11_body_keeps_legacy_calls(self):
+        process = self._build_against("11.8.02200.2")
+        prolog = process.prolog_procedure
+        epilog = process.epilog_procedure
+
+        self.assertIn("CubeGetLogChanges", prolog)
+        self.assertIn("CubeSetLogChanges", prolog)
+        self.assertIn("ExecuteCommand", epilog)
+        self.assertIn("CubeSetLogChanges", epilog)
+        self.assertNotIn("ASCIIDelete", epilog)
+
+    def test_v12_body_drops_forbidden_calls_and_uses_asciidelete(self):
+        process = self._build_against("12.2.5")
+        body = process.prolog_procedure + process.epilog_procedure
+
+        for symbol in self.V12_FORBIDDEN:
+            self.assertNotIn(
+                symbol,
+                body,
+                f"{symbol} must not appear in the v12 TI body",
+            )
+        self.assertIn("ASCIIDelete(pSourceFile)", process.epilog_procedure)
+
+    def test_v12_epilog_still_honours_delete_flag(self):
+        process = self._build_against("12.2.5")
+        epilog = process.epilog_procedure
+
+        # Cleanup remains guarded by pDeleteSourceFile so callers passing 0 keep the file.
+        self.assertIn("pDeleteSourceFile=1", epilog)
+        self.assertIn("ASCIIDelete(pSourceFile)", epilog)
 
 
 class TestBuildLoggingObjectsUpgradePath(unittest.TestCase):


### PR DESCRIPTION
## Summary

- `rushti build` now installs a TM1-version-aware `}rushti.load.results` TI body. On v12 the body drops `CubeGetLogChanges` / `CubeSetLogChanges` / `ExecuteCommand` (all removed or unsupported on v12) and uses `ASCIIDelete(pSourceFile)` for source-file cleanup. v11 body is unchanged.
- `_create_process` branches on `integerize_version(tm1.version, 2) >= 12` — reuses the existing pattern, no new helper, no extra TM1 round-trip (version is already cached on `TM1Service`).
- Same branching applied to `tests/integration/tm1_setup.py` so integration setup against v12 installs the correct body.

Closes #154.

## Test plan

- [x] `pytest tests/unit/test_tm1_build.py` — 27/27 pass, includes new `TestProcessBodyVersionSelection` asserting v11 keeps legacy calls and v12 has zero `CubeGetLogChanges` / `CubeSetLogChanges` / `ExecuteCommand` and uses `ASCIIDelete`.
- [x] `pytest tests/integration/test_v11_v12_build.py -m requires_tm1` — 10/10 pass against `tm1srv01` (v11) and `tm1srv02` (v12).
- [x] `pytest tests/integration/test_v11_v12_results.py -m requires_tm1` — 6/6 pass, including:
  - `TestResultPushV12::test_auto_load_results` — full `}rushti.load.results` execution on v12 with no TI error (smoking-gun proof the v12 body compiles and runs).
  - `TestResultPushV11::test_auto_load_results` (new) — symmetric coverage on v11 added in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)