### PR TITLE
Fix TM1Service kwarg collision when connection params set in config.ini

### DIFF
--- a/src/rushti/execution.py
+++ b/src/rushti/execution.py
@@ -195,11 +195,15 @@ def setup_tm1_services(
                 # case no connection file provided or connection file expired
                 if tm1_server_name not in tm1_services:
                     resolved_params = resolve_tm1_params(config, tm1_server_name)
-                    tm1_services[tm1_server_name] = TM1Service(
-                        **resolved_params,
-                        session_context=session_context,
-                        connection_pool_size=max_workers,
-                    )
+                    # RushTI-managed defaults; any value explicitly set in
+                    # config.ini takes precedence (avoids "multiple values for
+                    # keyword argument" when e.g. connection_pool_size is set).
+                    service_kwargs = {
+                        "session_context": session_context,
+                        "connection_pool_size": max_workers,
+                    }
+                    service_kwargs.update(resolved_params)
+                    tm1_services[tm1_server_name] = TM1Service(**service_kwargs)
 
                 if connection_file:
                     # implicitly re-connects if session is timed out


### PR DESCRIPTION
setup_tm1_services spread config.ini params via **params while also passing connection_pool_size and session_context explicitly, raising "got multiple values for keyword argument 'connection_pool_size'". The exception was swallowed as "instance not accessible", dropping the instance and surfacing a misleading KeyError downstream in validate_tasks.

Merge RushTI-managed values as defaults that config.ini can override. Add unit tests for the collision, the max_workers default, and session_context precedence.

## Description

<!-- Describe your changes in detail -->

## Type of Change

<!-- Mark the relevant option with an "x" -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] CI/CD or build changes

## Release Label

<!--
Maintainers: Apply ONE of these labels to trigger a release:
- `release:patch` - Bug fixes, minor improvements (1.5.0 → 1.5.1)
- `release:minor` - New features, non-breaking changes (1.5.0 → 1.6.0)
- `release:major` - Breaking changes (1.5.0 → 2.0.0)

No label = no release (for docs, CI changes, etc.)
-->

## Checklist

- [x] I have tested my changes locally
- [x] I have updated documentation if needed
- [x] My code follows the project's coding style
- [x] I have added tests if applicable
