### PR TITLE
docs(config): fix keyring template so set_password matches lookup

### DIFF
--- a/config/config.ini.template
+++ b/config/config.ini.template
@@ -48,5 +48,8 @@ ssl=True
 #   decode_b64=True
 #
 # Option 3: Keyring integration (most secure - password stored in OS keyring)
-#   Leave password empty and store in keyring:
-#   python -c "import keyring; keyring.set_password('TM1py', 'tm1srv01', 'mypassword')"
+#   1. Add `use_keyring=true` to this section (RushTI only queries keyring when opted in).
+#   2. Leave `password=` empty in this file.
+#   3. Store the secret so the service/account match RushTI's lookup —
+#      service = section name, account = user:
+#      python -c "import keyring; keyring.set_password('tm1srv01', 'admin', 'mypassword')"


### PR DESCRIPTION
## Summary

Documentation-only fix. `config/config.ini.template` showed a
`keyring.set_password` command that stored the secret under a
service/account combination RushTI never queries.

**Code lookup** (`src/rushti/tm1_integration.py:93`):
`keyring.get_password(<instance_name>, <user>)`

**Old template**:
`keyring.set_password('TM1py', 'tm1srv01', 'mypassword')` — stored under
service `'TM1py'`, account `<instance>`. Never matched.

**Fixed template**:
`keyring.set_password('<instance>', '<user>', 'mypassword')` — now
matches what the code reads.

Also documents the missing `use_keyring=true` step; keyring is opt-in
per section and the previous template omitted that.

No runtime change; template comment only.

## Test plan

- [ ] Copy template to `config.ini`, add `use_keyring=true`, run the
      updated `keyring.set_password` command, launch `rushti run ...`,
      confirm connection succeeds without the "no password found in
      keyring" warning.
- [ ] Run the old command against a fresh keyring, confirm the warning
      still fires (proves the old template was wrong).

🤖 Generated with [Claude Code](https://claude.com/claude-code)